### PR TITLE
Change interp.js debug to use debug node package

### DIFF
--- a/lib/interp.js
+++ b/lib/interp.js
@@ -33,10 +33,8 @@
 
 'use strict';
 
-var ints = require('buffer-more-ints');
-
-var debug = (process.env.DEBUG) ?
-  function(s) { console.log(s); } : function () {};
+var ints    = require('buffer-more-ints'),
+    debug   = require('debug')('Interpreter');
 
 function parse_int(bin, off, sizeInBytes, bigendian, signed) {
   switch (sizeInBytes) {

--- a/lib/interp.js
+++ b/lib/interp.js
@@ -34,7 +34,7 @@
 'use strict';
 
 var ints    = require('buffer-more-ints'),
-    debug   = require('debug')('Interpreter');
+    debug   = require('debug')('bitsyntax-Interpreter');
 
 function parse_int(bin, off, sizeInBytes, bigendian, signed) {
   switch (sizeInBytes) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": {
-      "name": "Michael Bridgen",
-      "email": "<mikeb@squaremobius.net>"
+    "name": "Michael Bridgen",
+    "email": "<mikeb@squaremobius.net>"
   },
   "name": "bitsyntax",
   "description": "Pattern-matching on byte buffers",
@@ -20,10 +20,11 @@
     "node": ">=0.6"
   },
   "dependencies": {
-    "buffer-more-ints": "0.0.2"
+    "buffer-more-ints": "0.0.2",
+    "debug": "^2.0.0"
   },
   "devDependencies": {
-    "pegjs": "0.7.x",
-    "mocha": "1.x"
+    "mocha": "1.x",
+    "pegjs": "0.7.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "buffer-more-ints": "0.0.2",
-    "debug": "^2.0.0"
+    "debug": "~2.0.0"
   },
   "devDependencies": {
     "mocha": "1.x",


### PR DESCRIPTION
Your custom debug method is playing havoc with anyone using the nodejs debug package.  Figured if I switched you to use it as well, you'd get the benefit and it'd cleanup the console spew for others.
